### PR TITLE
update to 2.0.35

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12-alpine as build
 
 WORKDIR /go/src/github.com/DNSCrypt/dnscrypt-proxy/
 
-ARG DNSCRYPT_PROXY_VERSION=2.0.34
+ARG DNSCRYPT_PROXY_VERSION=2.0.35
 ARG DNSCRYPT_PROXY_URL=https://github.com/DNSCrypt/dnscrypt-proxy/archive/
 
 ENV CGO_ENABLED 0

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER_REPO := klutchell/dnscrypt-proxy
-TAG := 2.0.34
+TAG := 2.0.35
 AUTHORS := Kyle Harding <https://klutchell.dev>
 SOURCE_URL := https://github.com/$(DOCKER_REPO)
 DESCRIPTION := dnscrypt-proxy is a flexible DNS proxy, with support for encrypted DNS protocols


### PR DESCRIPTION
https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.0.35